### PR TITLE
Make the crate `no_std`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@
 //! }
 //! ```
 
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 use std::marker::PhantomData;
 use std::fmt;
@@ -82,7 +81,8 @@ use std::default::Default;
 #[repr(C)]
 pub struct AtomicRef<'a, T: 'a> {
     data: AtomicUsize,
-    _marker: PhantomData<Mutex<&'a T>>,
+    // Make `AtomicRef` invariant over `'a` and `T`
+    _marker: PhantomData<&'a mut &'a mut T>,
 }
 
 /// You will probably never need to use this type. It exists mostly for internal


### PR DESCRIPTION
Removes dependency on `std`, making it possible to use this crate in a `no_std` environment.

Not sure about the minimum Rust version, but I confirmed it works with a Rust version as low as 1.15.1.