### PR TITLE
Make `AtomicRef::new` `const fn`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,8 @@ readme = "README.md"
 license = "MIT"
 keywords = ["atomic", "reference", "static"]
 
+[features]
+default = []
+nightly = []
+
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,4 @@ readme = "README.md"
 license = "MIT"
 keywords = ["atomic", "reference", "static"]
 
-[features]
-default = []
-nightly = []
-
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,11 +89,6 @@ pub struct AtomicRef<'a, T: 'a> {
 // `#![feature(const_fn)]`
 struct Invariant<'a, T: 'a>(&'a mut &'a mut T);
 
-/// Re-export `core` for `static_atomic_ref!` (which may be used in a
-/// non-`no_std` crate, where `core` is unavailable).
-#[doc(hidden)]
-pub use core::{mem as core_mem, ops as core_ops};
-
 /// An internal helper function for converting `Option<&'a T>` values to
 /// `*mut T` for storing in the `AtomicUsize`.
 const fn from_opt<'a, T>(p: Option<&'a T>) -> *mut T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@
 //! }
 //! ```
 
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 use std::marker::PhantomData;
 use std::fmt;
@@ -82,7 +81,8 @@ use std::default::Default;
 #[repr(C)]
 pub struct AtomicRef<'a, T: 'a> {
     data: AtomicUsize,
-    _marker: PhantomData<Mutex<&'a T>>,
+    // Make `AtomicRef` invariant over `'a` and `T`
+    _marker: PhantomData<&'a mut &'a mut T>,
 }
 
 /// You will probably never need to use this type. It exists mostly for internal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,6 @@
 //!    into `const fn`, making it callable in constant contexts.
 //!
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(const_fn))]
 #![cfg_attr(feature = "nightly", feature(const_if_match))]
 
 use core::sync::atomic::{AtomicPtr, Ordering};
@@ -92,8 +91,12 @@ use core::default::Default;
 pub struct AtomicRef<'a, T: 'a> {
     data: AtomicPtr<T>,
     // Make `AtomicRef` invariant over `'a` and `T`
-    _marker: PhantomData<&'a mut &'a mut T>,
+    _marker: PhantomData<Invariant<'a, T>>,
 }
+
+// Work-around for the construction of `PhantomData<&mut _>` requiring
+// `#![feature(const_fn)]`
+struct Invariant<'a, T: 'a>(&'a mut &'a mut T);
 
 /// You will probably never need to use this type. It exists mostly for internal
 /// use in the `static_atomic_ref!` macro.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,15 @@
 //!     assert!(res);
 //! }
 //! ```
+//!
+//! # Cargo Features
+//!
+//!  - `nightly` enables the use of unstable features. Turns [`AtomicRef::new`]
+//!    into `const fn`, making it callable in constant contexts.
+//!
 #![no_std]
-#![feature(const_fn)]
-#![feature(const_if_match)]
+#![cfg_attr(feature = "nightly", feature(const_fn))]
+#![cfg_attr(feature = "nightly", feature(const_if_match))]
 
 use core::sync::atomic::{AtomicPtr, Ordering};
 use core::marker::PhantomData;
@@ -174,12 +180,29 @@ macro_rules! static_atomic_ref {
     () => ();
 }
 
-/// An internal helper function for converting `Option<&'a T>` values to
-/// `*mut T` for storing in the `AtomicUsize`.
-const fn from_opt<'a, T>(p: Option<&'a T>) -> *mut T {
-    match p {
-        Some(p) => p as *const T as *mut T,
-        None => null_mut(),
+macro_rules! const_fn_if_nightly {
+    (
+        $( #[$meta:meta] )*
+        $vis:vis fn $($rest:tt)*
+    ) => {
+        $( #[$meta] )*
+        #[cfg(feature = "nightly")]
+        $vis const fn $($rest)*
+
+        $( #[$meta] )*
+        #[cfg(not(feature = "nightly"))]
+        $vis fn $($rest)*
+    };
+}
+
+const_fn_if_nightly! {
+    /// An internal helper function for converting `Option<&'a T>` values to
+    /// `*mut T` for storing in the `AtomicUsize`.
+    fn from_opt<'a, T>(p: Option<&'a T>) -> *mut T {
+        match p {
+            Some(p) => p as *const T as *mut T,
+            None => null_mut(),
+        }
     }
 }
 
@@ -190,20 +213,22 @@ unsafe fn to_opt<'a, T>(p: *mut T) -> Option<&'a T> {
 }
 
 impl<'a, T> AtomicRef<'a, T> {
-    /// Creates a new `AtomicRef`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use atomic_ref::AtomicRef;
-    ///
-    /// static VALUE: i32 = 10;
-    /// let atomic_ref = AtomicRef::new(Some(&VALUE));
-    /// ```
-    pub const fn new(p: Option<&'a T>) -> AtomicRef<'a, T> {
-        AtomicRef {
-            data: AtomicPtr::new(from_opt(p)),
-            _marker: PhantomData,
+    const_fn_if_nightly! {
+        /// Creates a new `AtomicRef`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use atomic_ref::AtomicRef;
+        ///
+        /// static VALUE: i32 = 10;
+        /// let atomic_ref = AtomicRef::new(Some(&VALUE));
+        /// ```
+        pub fn new(p: Option<&'a T>) -> AtomicRef<'a, T> {
+            AtomicRef {
+                data: AtomicPtr::new(from_opt(p)),
+                _marker: PhantomData,
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@
 //! }
 //! ```
 #![no_std]
+#![feature(const_fn)]
+#![feature(const_if_match)]
 
 use core::sync::atomic::{AtomicPtr, Ordering};
 use core::marker::PhantomData;
@@ -174,7 +176,7 @@ macro_rules! static_atomic_ref {
 
 /// An internal helper function for converting `Option<&'a T>` values to
 /// `*mut T` for storing in the `AtomicUsize`.
-fn from_opt<'a, T>(p: Option<&'a T>) -> *mut T {
+const fn from_opt<'a, T>(p: Option<&'a T>) -> *mut T {
     match p {
         Some(p) => p as *const T as *mut T,
         None => null_mut(),
@@ -198,7 +200,7 @@ impl<'a, T> AtomicRef<'a, T> {
     /// static VALUE: i32 = 10;
     /// let atomic_ref = AtomicRef::new(Some(&VALUE));
     /// ```
-    pub fn new(p: Option<&'a T>) -> AtomicRef<'a, T> {
+    pub const fn new(p: Option<&'a T>) -> AtomicRef<'a, T> {
         AtomicRef {
             data: AtomicPtr::new(from_opt(p)),
             _marker: PhantomData,


### PR DESCRIPTION
Turns `AtomicRef::new` into `const fn`, making it callable in constant contexts. ~~This currently requires the use of a nightly-only feature, so it's feature-gated by the Cargo feature `nightly`. This can be removed in the future when this unstable feature is stabilized.~~

~~Raises the minimum supported Rust version to 1.32.0 (regardless of the `nightly` feature).~~
As of 5e5a05703892e0f039500203ca7d1dcc26ed4098, this PR raises the minimum supported Rust version to 1.46.0.

This PR depends on #1.