### PR TITLE
Use the new trait object syntax in the documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //!     fn log(&self, msg: &str) {}
 //! }
 //! struct LoggerInfo {
-//!     logger: &'static (Logger + Sync)
+//!     logger: &'static (dyn Logger + Sync)
 //! }
 //!
 //! // The methods for working with our currently defined static logger


### PR DESCRIPTION
This PR replaces the old trait object syntax with the new one (`dyn TraitObject`) introduced in [1.27.0](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1270-2018-06-21).