### PR TITLE
Disallow Relaxed orderings for operations on AtomicRef

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atomic_ref"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Nika Layzell <nika@thelayzells.com>"]
 
 description = "Atomic &'a T types with support for static allocation"


### PR DESCRIPTION
This patch attempts to apply the recommended fix proposed in https://github.com/mystor/atomic_ref/issues/5#issue-1000023331.

Fixes #5 